### PR TITLE
Fixed Windows Caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,10 @@
-language: node_js
 sudo: false
+
+language: node_js
+node_js:
+  - "4"
+  - "6"
+  - "stable"
+
+script:
+  - npm run test

--- a/index.js
+++ b/index.js
@@ -54,7 +54,8 @@ SVGOFilter.prototype.optionsHash = function() {
 };
 
 SVGOFilter.prototype.cacheKeyProcessString = function(string, relativePath) {
-  return Filter.prototype.cacheKeyProcessString.call(this, string + this.optionsHash(), relativePath);
+  return Filter.prototype.cacheKeyProcessString.call(
+    this, string + this.optionsHash(), relativePath);
 };
 
 module.exports = SVGOFilter;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 var Filter = require('broccoli-persistent-filter');
 var stringify = require('json-stable-stringify');
-var sha1 = require('sha1');
 var RSVP = require('rsvp');
 var SVGO = require('svgo');
 
@@ -55,8 +54,7 @@ SVGOFilter.prototype.optionsHash = function() {
 };
 
 SVGOFilter.prototype.cacheKeyProcessString = function(string, relativePath) {
-  return sha1(this.optionsHash()) +
-    Filter.prototype.cacheKeyProcessString.call(this, string, relativePath);
+  return Filter.prototype.cacheKeyProcessString.call(this, string + this.optionsHash(), relativePath);
 };
 
 module.exports = SVGOFilter;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var Filter = require('broccoli-persistent-filter');
 var stringify = require('json-stable-stringify');
+var sha1 = require('sha1');
 var RSVP = require('rsvp');
 var SVGO = require('svgo');
 
@@ -54,7 +55,7 @@ SVGOFilter.prototype.optionsHash = function() {
 };
 
 SVGOFilter.prototype.cacheKeyProcessString = function(string, relativePath) {
-  return this.optionsHash() +
+  return sha1(this.optionsHash()) +
     Filter.prototype.cacheKeyProcessString.call(this, string, relativePath);
 };
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "broccoli-persistent-filter": "^1.2.0",
     "json-stable-stringify": "^1.0.1",
     "rsvp": "^3.2.1",
+    "sha1": "^1.1.1",
     "svgo": "^0.6.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "broccoli-persistent-filter": "^1.2.0",
     "json-stable-stringify": "^1.0.1",
     "rsvp": "^3.2.1",
-    "sha1": "^1.1.1",
     "svgo": "^0.6.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Whoa it's a Pull Request!
---
Fixes https://github.com/ivanvotti/ember-svg-jar/issues/24. This is a non-borky alternative approach to  #1, basically.

The gist is that Windows doesn't like colons in the filename, and this package uses the value of `optionsHash()` (a JSON string) to generate a cache key. `async-disk-cache` will happily try and use this key as a temp folder name, which leads to a fun ENOENT bomb-out on Windows. Doh!

In particular, this makes testing Ember addons that utilize `ember-svg-jar` troublesome on Windows (e.g. https://github.com/tim-evans/ember-file-upload/issues/36).

This PR simply runs `optionsHash()` through SHA-1 when computing the cache key, which magically solves everything. Wheee!

Why SHA-1?
---
It was convenient, and we needn't worry about being uber-cryptographically-secure here. Feel free to suggest a different hash algo choice if picky.

Why not Base64/URL encoding?
---
I didn't want to hit Windows' infamous MAX_PATH limitation (can't have paths longer than 260 characters on Windows 8.x and earlier), and a very long `optionsHash()` may potentially lead to that if we just encode it, so I took the hash function route.

Did writing this PR text take longer than actually coding the fix?
---
Yarp. 🌵  