### PR TITLE
pass a filepath to svgo.optimize()

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,9 +52,9 @@ class SVGOFilter extends PersistentFilter {
     this.optionsHash = stringify(options);
   }
 
-  processString(svg) {
+  processString(svg, relativePath) {
     return svg
-      ? this.optimize(svg).then(({ data }) => data)
+      ? this.optimize(svg, { path: relativePath }).then(({ data }) => data)
       : Promise.resolve('');
   }
 

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -133,4 +133,24 @@ describe('broccoli-svg-optimizer', () => {
     let outputNode = fixture.build(new SVGOptimizer(inputNode, options));
     return expect(outputNode).to.be.rejectedWith('promise error');
   });
+
+  it('passes file to optimize', () => {
+    class CustomSVGO {
+      optimize(svg, options) {
+        return Promise.resolve({ data: options && options.path });
+      }
+    }
+
+    let options = {
+      svgoConfig: {},
+      svgoModule: CustomSVGO,
+      persist: false
+    };
+
+    let outputNode = fixture.build(new SVGOptimizer(inputNode, options));
+
+    return expect(outputNode).to.eventually.deep.equal({
+      'test.svg': 'test.svg'
+    });
+  });
 });


### PR DESCRIPTION
in order to support prefixIds svgo rule.

@see: https://github.com/svg/svgo/pull/700